### PR TITLE
Fix issue with .qpkg symlink and container station

### DIFF
--- a/package_routines
+++ b/package_routines
@@ -34,13 +34,16 @@ detect_primary_volume() {
 
 resolve_qpkg_path() {
     QPKG_DIR="${PRIMARY_VOLUME}/.qpkg"
-    [ -L "$QPKG_DIR" ] && QPKG_DIR=$(readlink -f "$QPKG_DIR") || err_log "Failed to resolve .qpkg symlink."
+    if [ -L "$QPKG_DIR" ]; then
+        QPKG_DIR=$(readlink -f "$QPKG_DIR") || err_log "Failed to resolve .qpkg symlink."
+    fi
     QPKG_PATH="${QPKG_DIR}/${PACKAGE_NAME}"
     CONFIG_DIR="${QPKG_PATH}/config"
 }
 
 verify_container_station() {
-    [ ! -d "${PRIMARY_VOLUME}/.qpkg/container-station" ] && err_log "Container Station not installed."
+    CONTAINER_STATION_DIR=$(/sbin/getcfg container-station Install_Path -f /etc/config/qpkg.conf)
+    [ ! -d "${CONTAINER_STATION_DIR}" ] && err_log "Container Station not installed."
 }
 
 prepare_directories() {


### PR DESCRIPTION
Resolves two issues that caused the package to fail. 1) now only tries to validate a symlink for the .qpkg directory if it is, in fact, a symlink and 2) uses the actual configured install location to verify if container station is installed, as it may not be on the default volume. There are possibly more cleanups of this sort to be made, as some assumptions have been changed by qnap.